### PR TITLE
Add hyperlinks in home page cards

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -63,7 +63,7 @@
   name = "API"
   weight = 60
   identifier = "api"
-  url = ""
+  url = "/api/"
 
 [[social]]
   name = "GitHub"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,15 +19,15 @@
     <div class="container">
       <div class="row justify-content-center text-center">
         <div class="col-lg-5">
-          <h2 class="h4">Quick Start</h2>
+          <h2 class="h4"><a href="/docs/prologue/quick-start/">Quick Start</a></h2>
           <p>Follow these easy quick start guides to start your journey with phoenix code.</p>
         </div>
         <div class="col-lg-5">
-          <h2 class="h4">Live Preview</h2>
+          <h2 class="h4"><a href="/docs/livePreview/">Live Preview</a></h2>
           <p>Speed up website development with live preview. View changes to your code instantly without page reloads.</p>
         </div>
         <div class="col-lg-5">
-          <h2 class="h4">Extensions API</h2>
+          <h2 class="h4"><a href="/api/">Extensions API</a></h2>
           <p>With thousands of themes and extensions, customize almost any part of Phoenix to suit your needs.</p>
         </div>
       </div>


### PR DESCRIPTION
#16 

Add hyperlinks for the following in the home page:
1. Quick Start to `http://.../docs/prologue/quick-start/`
2. Live Preview to to `http://.../docs/livePreview/`
3. Extensions API to `http://.../api/` (in cards and navbar)