### PR TITLE
Change live preview page to features section

### DIFF
--- a/content/en/docs/features/_index.md
+++ b/content/en/docs/features/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Live Preview"
+title: "Features"
 description: ""
 lead: ""
 date: 2022-01-25T14:40:56+01:00

--- a/content/en/docs/features/live-preview.md
+++ b/content/en/docs/features/live-preview.md
@@ -8,9 +8,8 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "livePreview"
-weight: 999
+    parent: "features"
+weight: 700
 toc: true
-url: "/docs/livePreview/"
 ---
 Live Preview Page

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,7 +23,7 @@
           <p>Follow these easy quick start guides to start your journey with phoenix code.</p>
         </div>
         <div class="col-lg-5">
-          <h2 class="h4"><a href="/docs/livePreview/">Live Preview</a></h2>
+          <h2 class="h4"><a href="/docs/features/live-preview/">Live Preview</a></h2>
           <p>Speed up website development with live preview. View changes to your code instantly without page reloads.</p>
         </div>
         <div class="col-lg-5">


### PR DESCRIPTION
`Live preview` page is moved under `features` section in `docs`
new url: `http://.../docs/features/live-preview/`
#16 