### PR TITLE
Update ESLint linting info in FAQ

### DIFF
--- a/docs/04-Features/11-Problems Panel/01-html-lint.md
+++ b/docs/04-Features/11-Problems Panel/01-html-lint.md
@@ -41,3 +41,6 @@ Phoenix Code only supports plain JSON configuration file
 [.htmlvalidate.json](https://html-validate.org/usage/index.html#configuration).
 Other config files like `.htmlvalidate.js` and `.htmlvalidate.cjs` are not
 supported.
+
+#### Q: How is HTML linting triggered in Phoenix Code?
+HTML linting is automatically triggered when you save your file- errors and warnings are displayed in the problems panel.

--- a/docs/04-Features/11-Problems Panel/02-ESLint.md
+++ b/docs/04-Features/11-Problems Panel/02-ESLint.md
@@ -59,5 +59,7 @@ most common errors:
 
 2. Ensure to run `npm install` on the project and `node_modules` folder is
    present in the project at the top level.
-1. ESLint config files may have errors. Check if the problem message contains
+3. ESLint config files may have errors. Check if the problem message contains
    any references to your ESLint config file.
+
+*Note: ESLint runs automatically when you save your file. Issues and errors are displayed in the Problems Panel.*


### PR DESCRIPTION
Update the documentation to clarify that both ESLint and HTML linting run automatically when you save your files. Errors and issues will appear in the Problems Panel, and no manual steps are needed.