### PR TITLE
feat: expand API Docs by one level

### DIFF
--- a/expand-docs.js
+++ b/expand-docs.js
@@ -1,0 +1,21 @@
+// Script that automatically adds _category_.json file to 
+// API-Reference Dir to expand it by one level
+
+const path = require('path');
+const fs = require('fs');
+
+const API_DOCS = path.join('api', 'API-Reference');
+
+const categoryJsonTemplate = 
+`{
+    "collapsible": true,
+    "collapsed": false
+}`;
+
+if (fs.existsSync(API_DOCS)) {
+    const categoryJsonPath = path.join(API_DOCS, '_category_.json');
+    fs.writeFileSync(categoryJsonPath, categoryJsonTemplate, 'utf-8');
+    console.log('_category_.json created successfully!');
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@docusaurus/core": "3.5.2",
         "@docusaurus/plugin-google-gtag": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "buildAPIDocsProd": "shx rm -rf phoenix && shx rm -rf api/API-Reference && git clone -b prod --depth 1 --filter=blob:none --sparse https://github.com/phcode-dev/phoenix.git && cd phoenix && git sparse-checkout set docs/API-Reference && cd .. && shx cp -r phoenix/docs/API-Reference api/API-Reference && shx rm -rf phoenix",
-    "buildAPIDocsDev": "shx rm -rf phoenix && shx rm -rf api/API-Reference && git clone --depth 1 --filter=blob:none --sparse https://github.com/phcode-dev/phoenix.git && cd phoenix && git sparse-checkout set docs/API-Reference && cd .. && shx cp -r phoenix/docs/API-Reference api/API-Reference && shx rm -rf phoenix",
+    "buildAPIDocsProd": "shx rm -rf phoenix && shx rm -rf api/API-Reference && git clone -b prod --depth 1 --filter=blob:none --sparse https://github.com/phcode-dev/phoenix.git && cd phoenix && git sparse-checkout set docs/API-Reference && cd .. && shx cp -r phoenix/docs/API-Reference api/API-Reference && shx rm -rf phoenix && node expand-docs.js",
+    "buildAPIDocsDev": "shx rm -rf phoenix && shx rm -rf api/API-Reference && git clone --depth 1 --filter=blob:none --sparse https://github.com/phcode-dev/phoenix.git && cd phoenix && git sparse-checkout set docs/API-Reference && cd .. && shx cp -r phoenix/docs/API-Reference api/API-Reference && shx rm -rf phoenix && node expand-docs.js",
     "serveStatic": "http-server build -p 8001 -c-1"
   },
   "dependencies": {


### PR DESCRIPTION
Add `expand-docs.js` script that runs automatically during docusaurus build to add `_category_.json` file inside API-Reference directory.
`_category_.json` file can have properties like { collapsed: false } to expand the folder by one level.

Manually adding `_category_.json` won't work as during build process, API-Reference dir gets deleted/created everytime. 

All the commands are as it is. Everything is handled automatically.