### PR TITLE
fix: blog sidebar content getting trimmed

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,7 @@ const config = {
 				},
 				blog: {
 					showReadingTime: true,
+					blogSidebarCount: 'ALL',
 					// Please change this to your repo.
 					// Remove this to remove the "edit this page" links.
 					editUrl: "https://github.com/phcode-dev/docs/blob/main/"


### PR DESCRIPTION
The blog sidebar was only displaying the five most recent posts. This is the intended behavior, as stated by the Docusaurus developers: "To prevent SEO / duplicate content issues, blog posts should be truncated in list view."

This can be overridden by setting the blogSidebarCount property to "ALL" (default: 5).