### PR TITLE
fix: resolve GSC 404 errors with trailing-slash redirects and moved-p…

### DIFF
--- a/app-links.js
+++ b/app-links.js
@@ -90,15 +90,15 @@ export const appLinks = [
 	},
     {
 		from: '/app-links/auto-space-detection',
-		to: '/docs/editing-text/#auto-space-detection',
+		to: '/docs/editing-text#auto-space-detection',
 	},
     {
 		from: '/app-links/html-lint',
-		to: '/docs/Features/Problems Panel/html-lint/',
+		to: '/docs/Features/Problems Panel/html-lint',
 	},
     {
 		from: '/app-links/ESLint',
-		to: '/docs/Features/Problems Panel/ESLint/',
+		to: '/docs/Features/Problems Panel/ESLint',
 	},
     {
 		from: '/app-links/live-preview-settings',
@@ -106,11 +106,11 @@ export const appLinks = [
 	},
     {
 		from: '/app-links/editor-rulers',
-		to: '/docs/Features/editor-rulers/',
+		to: '/docs/Features/editor-rulers',
 	},
     {
 		from: '/app-links/find-in-files',
-		to: '/docs/Features/find-in-files/',
+		to: '/docs/Features/find-in-files',
 	},
     {
 		from: '/app-links/custom-snippets',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,7 +157,17 @@ const config = {
 		[
 			"@docusaurus/plugin-client-redirects",
 			{
-				redirects: appLinks,
+				redirects: [
+					...appLinks,
+					{ from: '/docs/Features/recent-files', to: '/docs/file-management#recent-files' },
+					{ from: '/docs/Features/live-preview-settings', to: '/docs/Features/Live Preview/live-preview-settings' },
+				],
+				createRedirects(existingPath) {
+					if (existingPath !== '/') {
+						return [existingPath + '/'];
+					}
+					return [];
+				},
 			}
 		]
 	],


### PR DESCRIPTION
…age redirects

Add createRedirects to generate trailing-slash redirect pages for GitHub Pages compatibility. Add explicit redirects for /docs/Features/recent-files and /docs/Features/live-preview-settings. Fix 5 trailing-slash targets in app-links.js.

## Summary

Brief explanation of the proposed changes.

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
